### PR TITLE
Support customizable maximum trail width

### DIFF
--- a/Languages/ChineseSimplified/Keyed/Gunplay.xml
+++ b/Languages/ChineseSimplified/Keyed/Gunplay.xml
@@ -4,6 +4,8 @@
 
   <GunplayEnableTrailsName>启用子弹轨迹</GunplayEnableTrailsName>
   <GunplayEnableTrailsDesc>子弹会拖出轨迹.</GunplayEnableTrailsDesc>
+  <GunplayMaxTrailWidthName>最大子弹轨迹宽度</GunplayMaxTrailWidthName>
+  <GunplayMaxTrailWidthDesc>子弹轨迹宽度不会超过指定的值.</GunplayMaxTrailWidthDesc>
   <GunplayEnableSoundsName>启用声音</GunplayEnableSoundsName>
   <GunplayEnableSoundsDesc>改变一些武器射击和子弹碰撞的声音（可能需要重启游戏）.</GunplayEnableSoundsDesc>
   <GunplayEnableWeaponAnimationsName>启用武器动态动画</GunplayEnableWeaponAnimationsName>

--- a/Languages/English/Keyed/Gunplay.xml
+++ b/Languages/English/Keyed/Gunplay.xml
@@ -4,6 +4,8 @@
   
   <GunplayEnableTrailsName>Enable trails</GunplayEnableTrailsName>
   <GunplayEnableTrailsDesc>Draw long trails for projectiles.</GunplayEnableTrailsDesc>
+  <GunplayMaxTrailWidthName>Maximum trail width</GunplayMaxTrailWidthName>
+  <GunplayMaxTrailWidthDesc>Trail width will not exceed the specified value.</GunplayMaxTrailWidthDesc>
   <GunplayEnableSoundsName>Enable sounds</GunplayEnableSoundsName>
   <GunplayEnableSoundsDesc>Change fire and projectile impact sounds for some weapons. May require restart.</GunplayEnableSoundsDesc>
   <GunplayEnableWeaponAnimationsName>Enable weapon animations</GunplayEnableWeaponAnimationsName>

--- a/Languages/Japanese/Keyed/Gunplay.xml
+++ b/Languages/Japanese/Keyed/Gunplay.xml
@@ -4,6 +4,8 @@
 
   <GunplayEnableTrailsName>発射物の表示を許可</GunplayEnableTrailsName>
   <GunplayEnableTrailsDesc>発射体(弾や矢)が目標へ飛んでいく軌跡を描画します。</GunplayEnableTrailsDesc>
+  <GunplayMaxTrailWidthName>最大トレイル幅</GunplayMaxTrailWidthName>
+  <GunplayMaxTrailWidthDesc>トレイルの幅が指定した値を超えないようにします。</GunplayMaxTrailWidthDesc>
   <GunplayEnableSoundsName>効果音を許可</GunplayEnableSoundsName>
   <GunplayEnableSoundsDesc>いくつかの武器のために射撃音と発射体が命中する音を変更します。ゲームを再起動する必要な場合があります。</GunplayEnableSoundsDesc>
   <GunplayEnableWeaponAnimationsName>武器のアニメを有効</GunplayEnableWeaponAnimationsName>

--- a/Source/GunplaySettings.cs
+++ b/Source/GunplaySettings.cs
@@ -11,6 +11,7 @@ namespace Gunplay
     public class GunplaySettings : ModSettings
     {
         public bool enableTrails = true;
+        public float maxTrailWidth = 0.4f;
         public bool enableSounds = true;
         public bool enableWeaponAnimations = true;
         public bool enableEffects = true;
@@ -20,6 +21,7 @@ namespace Gunplay
         override public void ExposeData()
         {
             Scribe_Values.Look(ref enableTrails, "enableTrails");
+            Scribe_Values.Look(ref maxTrailWidth, "maxTrailWidth", 0.4f);
             Scribe_Values.Look(ref enableSounds, "enenableSoundsableTrails");
             Scribe_Values.Look(ref enableWeaponAnimations, "enableWeaponAnimations");
             Scribe_Values.Look(ref enableEffects, "enableEffects");
@@ -31,6 +33,7 @@ namespace Gunplay
             Listing_Standard listing_Standard = new Listing_Standard();
             listing_Standard.Begin(inRect);
             listing_Standard.CheckboxLabeled("GunplayEnableTrailsName".Translate(), ref enableTrails, "GunplayEnableTrailsDesc".Translate());
+            listing_Standard.SliderLabeled("GunplayMaxTrailWidthName".Translate(), ref maxTrailWidth, "GunplayMaxTrailWidthDesc".Translate(), 0.001f, 2.0f, maxTrailWidth.ToString());
             listing_Standard.CheckboxLabeled("GunplayEnableSoundsName".Translate(), ref enableSounds, "GunplayEnableSoundsDesc".Translate());
             listing_Standard.CheckboxLabeled("GunplayEnableWeaponAnimationsName".Translate(), ref enableWeaponAnimations, "GunplayEnableWeaponAnimationsDesc".Translate());
             listing_Standard.CheckboxLabeled("GunplayEnableEffectsName".Translate(), ref enableEffects, "GunplayEnableEffectsDesc".Translate());

--- a/Source/ProjectileTrail.cs
+++ b/Source/ProjectileTrail.cs
@@ -36,7 +36,7 @@ namespace Gunplay
 
             length = speed * 15f;
             dir = (b - a).normalized;
-            width = proj.DamageAmount * 0.006f;
+            width = Mathf.Min(proj.DamageAmount * 0.006f, Gunplay.settings.maxTrailWidth);
 
 
             ProjectileTrailDef trailDef = def as ProjectileTrailDef;


### PR DESCRIPTION
Currently, there is no upper limit for the trail width, causing seemingly unreasonable trail for certain projectiles. For example, the firefoam shell has damage of 999999, which corresponds to a trail of width 5999.994.

This PR will add a maximum trail width setting and prevent the width from exceeding the specified value (0.4 by default).